### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ MCP23017 mcp = MCP23017(0x24);
 ```
 
 Additionaly, you can specify the `Wire` instance to use as a second argument. For instance `MCP23017(0x24, Wire1)`.  
-See included examples for furher usage.
+See included examples for further usage.


### PR DESCRIPTION
There was an inadvertent typo in the readme which was repaired by this commit.