### PR TITLE
Add begin() method

### DIFF
--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -30,6 +30,11 @@ void MCP23017::init()
 	writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
 }
 
+void MCP23017::begin()
+{
+	init();
+}
+
 void MCP23017::begin(uint8_t address)
 {
 	_deviceAddr = address;

--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -5,6 +5,11 @@ MCP23017::MCP23017(uint8_t address, TwoWire& bus) {
 	_bus = &bus;
 }
 
+MCP23017::MCP23017(TwoWire& bus) {
+	_deviceAddr = MCP23017_I2C_ADDRESS;
+	_bus = &bus;
+}
+
 MCP23017::~MCP23017() {}
 
 void MCP23017::init()
@@ -23,6 +28,12 @@ void MCP23017::init()
 
 	//enable all pull up resistors (will be effective for input pins only)
 	writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
+}
+
+void MCP23017::begin(uint8_t address)
+{
+	_deviceAddr = address;
+	init();
 }
 
 void MCP23017::portMode(MCP23017Port port, uint8_t directions, uint8_t pullups, uint8_t inverted)

--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -38,7 +38,7 @@ void MCP23017::begin()
 void MCP23017::begin(uint8_t address)
 {
 	_deviceAddr = address;
-	init();
+	begin();
 }
 
 void MCP23017::portMode(MCP23017Port port, uint8_t directions, uint8_t pullups, uint8_t inverted)

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -80,7 +80,8 @@ public:
 	 */
 	void begin();
 	/**
-	 * Overrides the I2C address set by the constructor. Implicitly calls init().
+	 * Overrides the I2C address set by the constructor. Implicitly calls begin().
+
 	 */
 	void begin(uint8_t address);
 	/**

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <Wire.h>
 
+#define MCP23017_I2C_ADDRESS 0x20    ///< The default I2C address of MCP23017.
 #define _MCP23017_INTERRUPT_SUPPORT_ ///< Enables support for MCP23017 interrupts.
 
 enum class MCP23017Port : uint8_t
@@ -65,10 +66,19 @@ public:
 	 * Instantiates a new instance to interact with a MCP23017 at the specified address.
 	 */
 	MCP23017(uint8_t address, TwoWire& bus = Wire);
+	/**
+	 * Instantiates a new instance to interact with a MCP23017 at the
+	 * MCP23017_I2C_ADDRESS default.
+	 */
+	MCP23017(TwoWire& bus = Wire);
 	~MCP23017();
 #ifdef _DEBUG
 	void debug();
 #endif
+	/**
+	 * May override the I2C address set by the constructor. Implicitly calls init().
+	 */
+	void begin(uint8_t address = MCP23017_I2C_ADDRESS);
 	/**
 	 * Initializes the chip with the default configuration.
 	 * Enables Byte mode (IOCON.BANK = 0 and IOCON.SEQOP = 1).

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -76,9 +76,13 @@ public:
 	void debug();
 #endif
 	/**
-	 * May override the I2C address set by the constructor. Implicitly calls init().
+	 * Uses the I2C address set during construction. Implicitly calls init().
 	 */
-	void begin(uint8_t address = MCP23017_I2C_ADDRESS);
+	void begin();
+	/**
+	 * Overrides the I2C address set by the constructor. Implicitly calls init().
+	 */
+	void begin(uint8_t address);
 	/**
 	 * Initializes the chip with the default configuration.
 	 * Enables Byte mode (IOCON.BANK = 0 and IOCON.SEQOP = 1).


### PR DESCRIPTION
It's usual for Arduino driver libs to have a constructor suitable for storage class static, and a `begin()` method that's called from `setup()`. The I2C address can thus be set in either way.
This PR adds that function.