### PR TITLE
Fix enumerator case in comment.

### DIFF
--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -191,8 +191,8 @@ public:
 
 	/**
 	 * Controls how the interrupt pins act with each other.
-	 * If intMode is SEPARATED, interrupt conditions on a port will cause its respective INT pin to active.
-	 * If intMode is OR, interrupt pins are OR'ed so an interrupt on one of the port will cause both pints to active.
+	 * If intMode is Separated, interrupt conditions on a port will cause its respective INT pin to active.
+	 * If intMode is Or, interrupt pins are OR'ed so an interrupt on one of the port will cause both pints to active.
 	 * 
 	 * Controls the IOCON.MIRROR bit. 
 	 * See "3.5.6 Configuration register".


### PR DESCRIPTION
The MCP23017InterruptMode enumerators unfortunately were spelled in all capitals in the comment of the function that uses them. This PR fixes that.