### PR TITLE
Don't hide I2C error status.

### DIFF
--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -161,9 +161,8 @@ uint8_t MCP23017::readRegister(MCP23017Register reg)
 {
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
-	_bus->endTransmission();
 	uint8_t retval = _bus->endTransmission();
-	_bus->requestFrom(_deviceAddr, (uint8_t)1);
+	retval &= _bus->requestFrom(_deviceAddr, (uint8_t)1);
 	return _bus->read();
 }
 
@@ -171,9 +170,8 @@ bool MCP23017::readRegister(MCP23017Register reg, uint8_t& portA, uint8_t& portB
 {
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
-	_bus->endTransmission();
 	uint8_t retval = _bus->endTransmission();
-	_bus->requestFrom(_deviceAddr, (uint8_t)2);
+	retval &= _bus->requestFrom(_deviceAddr, (uint8_t)2);
 	portA = _bus->read();
 	portB = _bus->read();
 	return !retval;

--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -12,7 +12,7 @@ MCP23017::MCP23017(TwoWire& bus) {
 
 MCP23017::~MCP23017() {}
 
-void MCP23017::init()
+bool MCP23017::init()
 {
 	//BANK = 	0 : sequential register addresses
 	//MIRROR = 	0 : use configureInterrupt 
@@ -24,21 +24,23 @@ void MCP23017::init()
 	//INTPOL = 	0 : interrupt active low
 	//UNIMPLMENTED 	0 : unimplemented: Read as ‘0’
 
-	writeRegister(MCP23017Register::IOCON, 0b00100000);
+	bool retval = writeRegister(MCP23017Register::IOCON, 0b00100000);
 
 	//enable all pull up resistors (will be effective for input pins only)
-	writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
+	retval &= writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
+
+	return retval;
 }
 
-void MCP23017::begin()
+bool MCP23017::begin()
 {
-	init();
+	return init();
 }
 
-void MCP23017::begin(uint8_t address)
+bool MCP23017::begin(uint8_t address)
 {
 	_deviceAddr = address;
-	begin();
+	return begin();
 }
 
 void MCP23017::portMode(MCP23017Port port, uint8_t directions, uint8_t pullups, uint8_t inverted)
@@ -135,21 +137,23 @@ uint16_t MCP23017::read()
 	return a | b << 8;
 }
 
-void MCP23017::writeRegister(MCP23017Register reg, uint8_t value)
+bool MCP23017::writeRegister(MCP23017Register reg, uint8_t value)
 {
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
 	_bus->write(value);
-	_bus->endTransmission();
+	uint8_t retval = _bus->endTransmission();
+	return !retval;
 }
 
-void MCP23017::writeRegister(MCP23017Register reg, uint8_t portA, uint8_t portB)
+bool MCP23017::writeRegister(MCP23017Register reg, uint8_t portA, uint8_t portB)
 {
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
 	_bus->write(portA);
 	_bus->write(portB);
-	_bus->endTransmission();
+	uint8_t retval = _bus->endTransmission();
+	return !retval;
 }
 
 
@@ -158,18 +162,21 @@ uint8_t MCP23017::readRegister(MCP23017Register reg)
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
 	_bus->endTransmission();
+	uint8_t retval = _bus->endTransmission();
 	_bus->requestFrom(_deviceAddr, (uint8_t)1);
 	return _bus->read();
 }
 
-void MCP23017::readRegister(MCP23017Register reg, uint8_t& portA, uint8_t& portB)
+bool MCP23017::readRegister(MCP23017Register reg, uint8_t& portA, uint8_t& portB)
 {
 	_bus->beginTransmission(_deviceAddr);
 	_bus->write(static_cast<uint8_t>(reg));
 	_bus->endTransmission();
+	uint8_t retval = _bus->endTransmission();
 	_bus->requestFrom(_deviceAddr, (uint8_t)2);
 	portA = _bus->read();
 	portB = _bus->read();
+	return !retval;
 }
 
 #ifdef _MCP23017_INTERRUPT_SUPPORT_

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -100,12 +100,12 @@ public:
 	/**
 	 * Uses the I2C address set during construction. Implicitly calls init().
 	 */
-	void begin();
+	bool begin();
 	/**
 	 * Overrides the I2C address set by the constructor. Implicitly calls begin().
 
 	 */
-	void begin(uint8_t address);
+	bool begin(uint8_t address);
 	/**
 	 * Initializes the chip with the default configuration.
 	 * Enables Byte mode (IOCON.BANK = 0 and IOCON.SEQOP = 1).
@@ -113,7 +113,7 @@ public:
 	 * 
 	 * See "3.2.1 Byte mode and Sequential mode".
 	 */
-	void init();
+	bool init();
 	/**
 	 * Controls the pins direction on a whole port at once.
 	 * 
@@ -202,7 +202,7 @@ public:
 	/**
 	 * Writes a single register value.
 	 */
-	void writeRegister(MCP23017Register reg, uint8_t value);
+	bool writeRegister(MCP23017Register reg, uint8_t value);
 	/**
 	 * Writes values to a register pair.
 	 * 
@@ -210,7 +210,7 @@ public:
 	 * you have to supply a portA register address to reg. Otherwise, values
 	 * will be reversed due to the way the MCP23017 works in Byte mode.
 	 */
-	void writeRegister(MCP23017Register reg, uint8_t portA, uint8_t portB);
+	bool writeRegister(MCP23017Register reg, uint8_t portA, uint8_t portB);
 	/**
 	 * Reads a single register value.
 	 */
@@ -222,7 +222,7 @@ public:
 	 * you have to supply a portA register address to reg. Otherwise, values
 	 * will be reversed due to the way the MCP23017 works in Byte mode.
 	 */
-	void readRegister(MCP23017Register reg, uint8_t& portA, uint8_t& portB);
+	bool readRegister(MCP23017Register reg, uint8_t& portA, uint8_t& portB);
 
 #ifdef _MCP23017_INTERRUPT_SUPPORT_
 

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -122,7 +122,7 @@ public:
 	 * 
 	 * See "3.5.1 I/O Direction register".
 	 */
-	void portMode(MCP23017Port port, uint8_t directions, uint8_t pullups = 0xFF, uint8_t inverted = 0x00);
+	bool portMode(MCP23017Port port, uint8_t directions, uint8_t pullups = 0xFF, uint8_t inverted = 0x00);
 	/**
 	 * Controls a single pin direction. 
 	 * Pin 0-7 for port A, 8-15 fo port B.
@@ -138,7 +138,7 @@ public:
 	 * This library pinMode function behaves like Arduino's standard pinMode for consistency.
 	 * [ OUTPUT | INPUT | INPUT_PULLUP ]
 	 */
-	void pinMode(uint8_t pin, uint8_t mode, bool inverted = false);
+	bool pinMode(uint8_t pin, uint8_t mode, bool inverted = false);
 
 	/**
 	 * Writes a single pin state.
@@ -149,7 +149,7 @@ public:
 	 * 
 	 * See "3.5.10 Port register".
 	 */
-	void digitalWrite(uint8_t pin, uint8_t state);
+	bool digitalWrite(uint8_t pin, uint8_t state);
 	/**
 	 * Reads a single pin state.
 	 * Pin 0-7 for port A, 8-15 for port B.
@@ -169,7 +169,7 @@ public:
 	 * 
 	 * See "3.5.10 Port register".
 	 */
-	void writePort(MCP23017Port port, uint8_t value);
+	bool writePort(MCP23017Port port, uint8_t value);
 	/**
 	 * Writes pins state to both ports.
 	 * 
@@ -178,7 +178,7 @@ public:
 	 * 
 	 * See "3.5.10 Port register".
 	 */
-	void write(uint16_t value);
+	bool write(uint16_t value);
 
 	/**
 	 * Reads pins state for a whole port.
@@ -234,28 +234,28 @@ public:
 	 * Controls the IOCON.MIRROR bit. 
 	 * See "3.5.6 Configuration register".
 	 */
-	void interruptMode(MCP23017InterruptMode intMode);
+	bool interruptMode(MCP23017InterruptMode intMode);
 	/**
 	 * Configures interrupt registers using an Arduino-like API.
 	 * mode can be one of CHANGE, FALLING or RISING.
 	 */
-	void interrupt(MCP23017Port port, uint8_t mode);
+	bool interrupt(MCP23017Port port, uint8_t mode);
 	/**
 	 * Disable interrupts for the specified port.
 	 */
-	void disableInterrupt(MCP23017Port port);
+	bool disableInterrupt(MCP23017Port port);
 	/**
 	 * Reads which pin caused the interrupt.
 	 */
-	void interruptedBy(uint8_t& portA, uint8_t& portB);
+	bool interruptedBy(uint8_t& portA, uint8_t& portB);
 	/**
 	 * Clears interrupts on both ports.
 	 */
-	void clearInterrupts();
+	bool clearInterrupts();
 	/**
 	 * Clear interrupts on both ports. Returns port values at the time the interrupt occured.
 	 */
-	void clearInterrupts(uint8_t& portA, uint8_t& portB);
+	bool clearInterrupts(uint8_t& portA, uint8_t& portB);
 
 #endif
 };


### PR DESCRIPTION
Prior to this PR, most functions in the MCP23017 API fail silently, despite the I2C Wire libs error status return code.
Now, like other I2C slave driver libs, the return type is bool instead of void, so the user can determine the success of the operations.