### PR TITLE
Disable pullups on init

### DIFF
--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -25,9 +25,6 @@ void MCP23017::init()
 	//UNIMPLMENTED 	0 : unimplemented: Read as ‘0’
 
 	writeRegister(MCP23017Register::IOCON, 0b00100000);
-
-	//enable all pull up resistors (will be effective for input pins only)
-	//writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
 }
 
 void MCP23017::begin()

--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -27,7 +27,7 @@ void MCP23017::init()
 	writeRegister(MCP23017Register::IOCON, 0b00100000);
 
 	//enable all pull up resistors (will be effective for input pins only)
-	writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
+	//writeRegister(MCP23017Register::GPPU_A, 0xFF, 0xFF);
 }
 
 void MCP23017::begin()


### PR DESCRIPTION
don't enable the pull-up in the init method. Pins not yet set to output will be high and can cause trouble.  Fixes https://github.com/blemasle/arduino-mcp23017/issues/31