### PR TITLE
add constructor without arguments

### DIFF
--- a/src/MCP23017.cpp
+++ b/src/MCP23017.cpp
@@ -10,6 +10,10 @@ MCP23017::MCP23017(TwoWire& bus) {
 	_bus = &bus;
 }
 
+
+MCP23017::MCP23017() {}
+
+
 MCP23017::~MCP23017() {}
 
 void MCP23017::init()

--- a/src/MCP23017.h
+++ b/src/MCP23017.h
@@ -93,6 +93,7 @@ public:
 	 * MCP23017_I2C_ADDRESS default.
 	 */
 	MCP23017(TwoWire& bus = Wire);
+	MCP23017();
 	~MCP23017();
 #ifdef _DEBUG
 	void debug();


### PR DESCRIPTION
i tried to pass an instance of MCP23017 by reference to the constructor of another class.  
Doing this seems to require a constructor without arguments. I added the constructor without arguments with this change. 


this is my own constructor; it is a wrapper class so i can create objects for each pin seperately and it inherits from my base class so i can make abstractions of different kinds of IO expanders, pins on the arduino itself, ...

`MCP23017IO::MCP23017IO(MCP23017 &ic, uint8_t pin)
  : IO() {
  pin = pin;
  ic = ic;
}`